### PR TITLE
Skip rescheduling a job if it has already been removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
  - 2.0.0
  - 2.1.2
  - jruby-9.0.0.0.pre1
+gemfile:
+- gemfiles/sidekiq310.gemfile
+- gemfiles/sidekiq334.gemfile
 script: bundle exec rake test
 addons:
  code_climate:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ easily rate-limit creation of Sidekiq jobs.
 
 When you create a job via `#perform_in` on a Worker with debounce enabled,
 Sidekiq::Debounce will prevent other jobs with the same arguments from being
-created until the job has run.  Every time you create another job with those
+created until the time has passed. Every time you create another job with those
 same arguments prior to the job being run, the timer is reset and the entire
 period must pass again before the job is executed.
 

--- a/gemfiles/sidekiq310.gemfile
+++ b/gemfiles/sidekiq310.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'sidekiq', '3.1.0'
+
+gemspec path: '../'

--- a/gemfiles/sidekiq334.gemfile
+++ b/gemfiles/sidekiq334.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'sidekiq', '3.3.4'
+
+gemspec path: '../'

--- a/lib/sidekiq/debounce.rb
+++ b/lib/sidekiq/debounce.rb
@@ -46,7 +46,7 @@ module Sidekiq
 
     def reschedule(job, at)
       scheduled_job = scheduled_set.find_job(job['jid'])
-      scheduled_job.reschedule(at)
+      scheduled_job.reschedule(at) if scheduled_job.present?
       job
     end
 


### PR DESCRIPTION
sidekiq processed the job, or it was scheduled using perform_in somewhere else
